### PR TITLE
Add camera cron

### DIFF
--- a/cli/camera/schedule.sh
+++ b/cli/camera/schedule.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+INTERVAL=$1
+DIR=$(dirname "$(readlink -f "$0")")
+CRONCMD="$DIR/take-photo.sh"
+CRONJOB=`printf '%d * * * * %s' $INTERVAL $CRONCMD`
+
+if [ "$INTERVAL" = "0" ]; then
+	( crontab -l | grep -v -F "$CRONCMD" ) | crontab -
+else
+	( crontab -l | grep -v -F "$CRONCMD" ; echo "$CRONJOB" ) | crontab -
+fi

--- a/plugin/blog-in-a-box.php
+++ b/plugin/blog-in-a-box.php
@@ -24,14 +24,6 @@ function biab_is_module_enabled( $module ) {
 	return false;
 }
 
-if ( !function_exists( 'pr' ) ) {
-	function pr( $things ) {
-		echo '<pre>';
-		print_r( $things );
-		echo '</pre>';
-	}
-}
-
 class BlogInBox {
 	private static $instance = null;
 

--- a/plugin/camera/control.php
+++ b/plugin/camera/control.php
@@ -7,6 +7,16 @@ class CameraControl extends BiabControl {
 
 	}
 
+	public function set_schedule( $interval ) {
+		$result = $this->request( self::DEVICE, 'schedule', intval( $interval, 10 ) );
+
+		if ( $result['retval'] === 0 ) {
+			return true;
+		}
+
+		return false;
+	}
+
 	public function save_settings( $settings ) {
 		$cmd = array(
 			'-q '.$settings['quality'],

--- a/plugin/camera/cron.php
+++ b/plugin/camera/cron.php
@@ -1,50 +1,15 @@
 <?php
 
 class CameraCron {
-	public function __construct() {
-		add_filter( 'cron_schedules', array( $this, 'cron_schedule' ) );
-	}
+	const OPTION_NAME = 'biab_camera_interval';
 
 	public function set( $interval ) {
 		$interval = max( 0, $interval );
 
-		update_option( 'biab_camera_interval', $interval );
-
-		if ( $interval === 0 ) {
-			return $this->disable();
-		}
-
-		return $this->enable();
+		update_option( self::OPTION_NAME, $interval );
 	}
 
-	private function disable() {
-		wp_unschedule_event( wp_next_scheduled( 'biab_photo' ), array( $this, 'take_photo' ) );
-	}
-
-	private function enable( $interval ) {
-		$next = wp_next_scheduled( 'biab_photo' );
-
-		if ( $next ) {
-			$this->disable_cron();
-		}
-
-		wp_schedule_event( time() + $interval, 'biab', array( $this, 'take_photo' ) );
-	}
-
-	public function get_interval() {
-		return intval( get_option( 'biab_camera_interval' ), 10 );
-	}
-
-	public function cron_schedule( $schedules ) {
-		$interval = $this->get_interval();
-
-		if ( $interval > 0 ) {
-			$schedules['biab'] = array(
-				'interval' => $interval,
-				'display'  => esc_html__( 'BIAB' ),
-			);
-		}
-
-		return $schedules;
+	public function get() {
+		return intval( get_option( self::OPTION_NAME ), 10 );
 	}
 }

--- a/plugin/control.php
+++ b/plugin/control.php
@@ -4,6 +4,14 @@ if ( !defined( 'ABSPATH' ) ) {
 	die( 'Nope' );
 }
 
+if ( !function_exists( 'pr' ) ) {
+	function pr( $things ) {
+		echo '<pre>';
+		print_r( $things );
+		echo '</pre>';
+	}
+}
+
 class BiabControl {
 	const DEFAULT_PATH = '/opt/bloginabox';
 	const OPTION_NAME = 'biab_path';
@@ -19,7 +27,7 @@ class BiabControl {
 	}
 
 	public function set_path( $path ) {
-		update_option( self::OPTION_NAME, $path );
+		update_option( self::OPTION_NAME, rtrim( $path, '/' ) );
 	}
 
 	protected function request( $device, $command, $data ) {


### PR DESCRIPTION
Add camera cron by allowing the crontab to be set

This has less overhead than using WP cron, and means we dont need a cronjob to ping WP which spawns a shell to run the camera code which spawns WP to push data into WP!

Instead we just have a cronjob that runs the camera and pushes data into WP