### PR TITLE
Removes the 'wp' param from event listeners

### DIFF
--- a/cli/cron/index.js
+++ b/cli/cron/index.js
@@ -23,7 +23,7 @@ function intervalAsCron( interval, period ) {
 function updateCrontab( command, interval, success_cb, error_cb ) {
 	const cmd = `( crontab -l | grep -v -F "${ command }" ; echo "${ interval } ${ command }" ) | crontab -`;
 
-	debug( 'Setting camera schedule: ' + interval );
+	debug( 'Adding to cron: ' + interval );
 	debug( 'Crontab comamnd: ' + cmd );
 
 	exec( cmd, ( error, stdout ) => {
@@ -38,7 +38,7 @@ function updateCrontab( command, interval, success_cb, error_cb ) {
 function removeCrontab( command, success_cb, error_cb ) {
 	const cmd = `( crontab -l | grep -v -F "${ command }" ) | crontab -`;
 
-	debug( 'Removing camera from schedule' );
+	debug( 'Removing from cron' );
 	debug( 'Crontab comamnd: ' + cmd );
 
 	exec( cmd, ( error, stdout ) => {
@@ -50,11 +50,11 @@ function removeCrontab( command, success_cb, error_cb ) {
 	} );
 }
 
-module.exports = function( command, wp, schedule, success, error ) {
+module.exports = function( command, schedule, success, error ) {
 	const interval = getInterval( schedule );
 	const period = getPeriod( schedule );
 
-	debug( `Camera schedule: "${ schedule }" => ${ interval } ${ period }` );
+	debug( `Cron schedule: "${ schedule }" => ${ interval } ${ period }` );
 
 	if ( interval > 0 && isValidPeriod( period ) ) {
 		return updateCrontab( command, intervalAsCron( interval, period ), success, error );

--- a/cli/devices/camera/camera-settings.js
+++ b/cli/devices/camera/camera-settings.js
@@ -11,7 +11,7 @@ const fs = require( 'fs' );
 
 const config = require( 'config' );
 
-function saveSettings( wp, settings ) {
+function saveSettings( settings ) {
 	debug( 'Camera settings: ' + settings );
 
 	config.set( 'camera_settings', { args: settings } );

--- a/cli/devices/camera/index.js
+++ b/cli/devices/camera/index.js
@@ -14,7 +14,7 @@ const photoToPost = require( './photo-to-post' );
 const cameraSettings = require( './camera-settings' );
 const schedule = require( './schedule' );
 
-function returnPost( wp, post ) {
+function returnPost( post ) {
 	this.emit( 'result', JSON.stringify( { id: post.id } ) );
 }
 

--- a/cli/devices/camera/photo-to-post.js
+++ b/cli/devices/camera/photo-to-post.js
@@ -4,6 +4,12 @@
 
 const debug = require( 'debug' )( 'biab:camera:photo-to-post' );
 
+/**
+ * External dependencies
+ */
+
+const wp = require( 'wordpress' );
+
 const getPhotoName = () => 'photo-' + process.pid + '.jpg';
 const getPostTitle = title => title ? title : new Date().toLocaleString();
 
@@ -14,11 +20,10 @@ function getImageContent( media ) {
 	return `<img src="${ sized }" width="${ width }" height="${ height }" />`;
 }
 
-function createPost( wordpress, emitter, media, title ) {
+function createPost( emitter, media, title ) {
 	debug( 'Creating post' );
 
-	wordpress
-		.posts()
+	wp.posts()
 		.create( {
 			title: title,
 			featured_media: media.id,
@@ -27,14 +32,14 @@ function createPost( wordpress, emitter, media, title ) {
 		} )
 		.then( response => {
 			debug( 'Post ' + response.id + ' created: ' + response.link );
-			emitter.emit( 'photo-published', wordpress, response );
+			emitter.emit( 'photo-published', response );
 		} )
 		.catch( error => {
 			emitter.emit( 'error', 'Unable to save photo to WP - ' + error.message );
 		})
 }
 
-function uploadPhoto( wp, commandData, photo ) {
+function uploadPhoto( commandData, photo ) {
 	debug( 'Uploading photo with title: ' + getPostTitle( commandData ) );
 
 	wp.media()
@@ -42,7 +47,7 @@ function uploadPhoto( wp, commandData, photo ) {
 		.create()
 		.then( response => {
 			debug( 'Photo ' + response.id + ' uploaded: ' + response.source_url );
-			createPost( wp, this, response, getPostTitle( commandData ) );
+			createPost( this, response, getPostTitle( commandData ) );
 		} )
 		.catch( error => {
 			this.emit( 'error', 'Unable to save photo to WP - ' + error.message );

--- a/cli/devices/camera/schedule.js
+++ b/cli/devices/camera/schedule.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 
 const cron = require( 'cron' );
 
-function setCameraCron( wp, schedule ) {
+function setCameraCron( schedule ) {
 	const cmd = path.resolve( path.join( __dirname, '..', 'biab' ) ) + ' camera-take-photo';
 	const success = () => {
 		this.emit( 'result', 'scheduled' );
@@ -19,7 +19,7 @@ function setCameraCron( wp, schedule ) {
 		this.emit( 'error', msg );
 	};
 
-	cron( cmd, wp, schedule, success, error );
+	cron( cmd, schedule, success, error );
 }
 
 module.exports = setCameraCron;

--- a/cli/devices/camera/take-photo.js
+++ b/cli/devices/camera/take-photo.js
@@ -12,7 +12,7 @@ const debug = require( 'debug' )( 'biab:camera:take-photo' );
 const config = require( 'config' );
 const constants = require( './constants' );
 
-function takePhoto( wp, commandData ) {
+function takePhoto( commandData ) {
 	const camera = config.get( constants.setting, constants.defaults );
 	const cmd = `/usr/bin/raspistill -n --timeout 500 ${ camera.args } -o -`;
 
@@ -24,7 +24,7 @@ function takePhoto( wp, commandData ) {
 			this.emit( 'error', 'Unable to open camera' );
 		} else {
 			debug( 'Photo taken - ' + stdout.length + ' bytes' );
-			this.emit( 'photo-to-wp', wp, commandData, stdout );
+			this.emit( 'photo-to-wp', commandData, stdout );
 		}
 	} );
 }

--- a/cli/devices/camera/take-snapshot.js
+++ b/cli/devices/camera/take-snapshot.js
@@ -12,7 +12,7 @@ const debug = require( 'debug' )( 'biab:camera:take-snapshot' );
 const config = require( 'config' );
 const constants = require( './constants' );
 
-function takePhoto( wp, commandData ) {
+function takePhoto( commandData ) {
 	const camera = config.get( constants.setting, constants.defaults );
 	const cmd = `/usr/bin/raspistill -w 640 -h 480 -n --timeout 500 ${ camera.args } -o /opt/wp/wp-content/uploads/snapshot.jpg`;
 

--- a/cli/devices/sensehat/capture.js
+++ b/cli/devices/sensehat/capture.js
@@ -5,7 +5,7 @@
 const exec = require( 'child_process' ).exec;
 const debug = require( 'debug' )( 'biab:sensehat:capture' );
 
-function capture( wp, commandData ) {
+function capture( commandData ) {
 	const cmd = `/usr/bin/python ${ __dirname }/capture.py`;
 
 	debug( 'Capturing data: ' + cmd );
@@ -17,7 +17,7 @@ function capture( wp, commandData ) {
 		} else {
 			const json = JSON.parse( stdout );
 			debug( 'Data captured - temp=' + json.temperature + ' humidity=' + json.humidity + ' pressure=' + json.pressure );
-			this.emit( 'sensehat-reading', wp, commandData, json );
+			this.emit( 'sensehat-reading', commandData, json );
 		}
 	} );
 }

--- a/cli/devices/sensehat/data-to-wp.js
+++ b/cli/devices/sensehat/data-to-wp.js
@@ -6,7 +6,7 @@ const exec = require( 'child_process' ).exec;
 const debug = require( 'debug' )( 'biab:sensehat:data-to-wp' );
 
 // TODO: convert this to use the wp REST API
-function dataToWP( wp, commandData, json ) {
+function dataToWP( commandData, json ) {
 	const cmd = `/usr/bin/php ${ __dirname }/data-to-wp.php '${ JSON.stringify( json ) }'`;
 
 	debug( 'Sending data to WordPress ' + cmd );

--- a/cli/devices/sensehat/display.js
+++ b/cli/devices/sensehat/display.js
@@ -14,15 +14,15 @@ function setDisplay( python, arg ) {
 	spawn( '/usr/bin/python', [ __dirname + '/display/' + python, arg ], { stdio: 'ignore', detached: true } );
 }
 
-function showReading( wp, commandData, json ) {
+function showReading( commandData, json ) {
 	setDisplay( 'show-message.py', round( json.temperature, 1 ) + 'C' );
 }
 
-function showCamera( wp, commandData, json ) {
+function showCamera( commandData, json ) {
 	setDisplay( 'show-image.py', __dirname + '/display/image/mean-face.png' );
 }
 
-function clearDisplay( wp, commandData, json ) {
+function clearDisplay( commandData, json ) {
 	setDisplay( 'clear.py' );
 }
 

--- a/cli/devices/sensehat/schedule.js
+++ b/cli/devices/sensehat/schedule.js
@@ -10,7 +10,7 @@ const path = require( 'path' );
 
 const cron = require( 'cron' );
 
-function setSensehatCron( wp, schedule ) {
+function setSensehatCron( schedule ) {
 	const cmd = path.resolve( path.join( __dirname, '..', 'biab' ) ) + ' sensehat-capture';
 	const success = () => {
 		this.emit( 'result', 'scheduled' );
@@ -19,7 +19,7 @@ function setSensehatCron( wp, schedule ) {
 		this.emit( 'error', msg );
 	};
 
-	cron( cmd, wp, schedule, success, error );
+	cron( cmd, schedule, success, error );
 }
 
 module.exports = setSensehatCron;

--- a/cli/index.js
+++ b/cli/index.js
@@ -4,7 +4,6 @@
 
 const EventEmitter = require( 'events' ).EventEmitter;
 const process = require( 'process' );
-const WPAPI = require( 'wpapi' );
 
 const debug = require( 'debug' )( 'biab:main' );
 
@@ -12,11 +11,7 @@ const debug = require( 'debug' )( 'biab:main' );
  * External dependencies
  */
 
-const auth = require( './auth.json' );
-
-const wp = new WPAPI( auth );
 const deviceEmitter = new EventEmitter();
-
 const devices = require( 'devices' )( deviceEmitter );
 
 if ( process.argv.length < 3 ) {
@@ -36,7 +31,7 @@ function runCommand( emitter, command, commandData ) {
 		console.log( json );
 	} );
 
-	emitter.emit( command, wp, commandData );
+	emitter.emit( command, commandData );
 
 	if ( emitter.listenerCount( command ) === 0 ) {
 		debug( 'No handler for command ' + command );

--- a/cli/wordpress/index.js
+++ b/cli/wordpress/index.js
@@ -1,0 +1,5 @@
+const WPAPI = require( 'wpapi' );
+const auth = require( '../auth.json' );
+const wp = new WPAPI( auth );
+
+module.exports = wp;


### PR DESCRIPTION
Rather than passing a wpapi object through to all event listeners we moved it into a module, and let devices require it when needed